### PR TITLE
Add styled greetings with greet_as method in Greeting class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 `main.rb` - runs each function available
 
-`lib/greeter.rb` - a class that implements functionality to greet people
+`lib/greeter.rb` - a class that implements functionality to greet people; methods include:
+* `Greeter#greet` - returns an anonymous friendly greeting
+* `Greeter#greet_by_name` - returns a greeting to the person named
+* `Greeter#greet_as` - returns a greeting to the person named, styled with the given style
+* `Greeter::greeting_styles` - with no arguments, returns the available greeting styles as a `Hash`; with a style identifier (`Symbol`), returns the styled greeting for that style; supported styles are:
+  - `:pirate`
+  - `:victorian`
+  - `:aussie`
+
 
 ## To run tests
 ```

--- a/lib/greeter.rb
+++ b/lib/greeter.rb
@@ -1,9 +1,33 @@
 class Greeter
+  @@greeting_styles = {
+    pirate: 'Yar! Ahoy',
+    victorian: 'Ever so delightful to meet thee',
+    aussie: "G'day"
+  }
+  def self.greeting_styles(style)
+    return @@greeting_styles[style] if @@greeting_styles.has_key? style
+    ''
+  end
+  
   def greet
     'Hello!'
   end
   def greet_by_name name
     return self.greet if name == '' or name.class != String
     "Hello, #{name}!"
+  end
+  def greet_as name, options
+    return self.greet_by_name name unless 
+      options.class == Hash and 
+      options.has_key? :as and 
+      !options[:as].nil?
+    styled_greeting = self.class.greeting_styles(options[:as])
+    if name.class != String or name == ''
+      ending = '!'
+    else 
+      ending = ", #{name}!"
+    end
+    return "Hello#{ending}" if styled_greeting.nil? or styled_greeting == ''
+    "#{styled_greeting}#{ending}"
   end
 end

--- a/lib/greeter.rb
+++ b/lib/greeter.rb
@@ -4,7 +4,8 @@ class Greeter
     victorian: 'Ever so delightful to meet thee',
     aussie: "G'day"
   }
-  def self.greeting_styles(style)
+  def self.greeting_styles(style = nil)
+    return @@greeting_styles if style.nil?
     return @@greeting_styles[style] if @@greeting_styles.has_key? style
     ''
   end

--- a/main.rb
+++ b/main.rb
@@ -7,6 +7,10 @@ puts g.greet
 puts g.greet_by_name 'Alice'
 puts g.greet_by_name 'Ben'
 
+puts "Supported styles:"
+Greeter.greeting_styles.each do |k, v|
+  puts " -> #{k.inspect}"
+end
 puts g.greet_as 'Alice', as: :pirate
 puts g.greet_as 'Alice', as: :victorian
 puts g.greet_as 'Alice', as: :aussie

--- a/main.rb
+++ b/main.rb
@@ -6,3 +6,7 @@ puts g.greet
 
 puts g.greet_by_name 'Alice'
 puts g.greet_by_name 'Ben'
+
+puts g.greet_as 'Alice', as: :pirate
+puts g.greet_as 'Alice', as: :victorian
+puts g.greet_as 'Alice', as: :aussie

--- a/spec/greeter_spec.rb
+++ b/spec/greeter_spec.rb
@@ -13,6 +13,7 @@ describe Greeter do
       expect(@greeter.greet).to eq('Hello!')
     end
   end
+
   describe 'Greeter#greet_by_name' do
     before(:each) do
       @name = ''
@@ -46,6 +47,83 @@ describe Greeter do
       end
       it 'greets the user by name' do
         expect(@result).to eq("Hello, #{@name}!")
+      end
+    end
+  end
+
+  describe 'Greeter#greet_as' do
+    context 'given no options' do
+      it 'falls back to 1 argument greet_by_name method' do
+        expect(@greeter.greet_as('', nil)).to eq(@greeter.greet_by_name '')
+        expect(@greeter.greet_as('Bob', nil)).to eq(@greeter.greet_by_name 'Bob')
+      end
+    end
+    context 'given a nil style' do
+      it 'falls back to 1 argument greet_by_name method' do
+        expect(@greeter.greet_as('', as: nil)).to eq(@greeter.greet_by_name '')
+        expect(@greeter.greet_as('Bob', as: nil)).to eq(@greeter.greet_by_name 'Bob')
+      end
+    end
+    context 'given an empty string' do
+      before(:each) do
+        @name = ''
+      end
+      it 'returns a string' do
+        @style = nil
+        @result = @greeter.greet_as(@name, as: @style)
+        expect(@result.class).to be(String)
+      end
+      context 'given a nil style' do
+        it 'falls back to 0 argument greet method' do
+          @style = nil
+          @result = @greeter.greet_as(@name, as: @style)
+          expect(@result).to eq(@greeter.greet)
+        end
+      end
+      context 'given an unknown style' do
+        it 'falls back to 0 argument greet method' do
+          @style = :zyx1
+          @result = @greeter.greet_as(@name, as: @style)
+          expect(@result).to eq(@greeter.greet)
+        end
+      end
+      context 'given a known style' do
+        it 'displays a styled anonymous greeting' do
+          @style = :pirate
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("Yar! Ahoy!")
+          @style = :victorian
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("Ever so delightful to meet thee!")
+          @style = :aussie
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("G'day!")
+        end
+      end
+    end
+    context 'given a name' do
+      before(:each) do
+        @name = 'Alice'
+      end
+      context 'given an unknown style' do
+        it 'falls back to 1 argument greet_by_name method' do
+          @style = :zyx1
+          @result = @greeter.greet_as(@name, as: @style)
+          expect(@result).to eq(@greeter.greet_by_name @name)
+        end
+      end
+      context 'given a known style' do
+        it 'displays a styled greeting with the name' do
+          @style = :pirate
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("Yar! Ahoy, #{@name}!")
+          @style = :victorian
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("Ever so delightful to meet thee, #{@name}!")
+          @style = :aussie
+          @result = @greeter.greet_as @name, as: @style
+          expect(@result).to eq("G'day, #{@name}!")
+        end
       end
     end
   end

--- a/spec/greeter_spec.rb
+++ b/spec/greeter_spec.rb
@@ -51,6 +51,27 @@ describe Greeter do
     end
   end
 
+  describe 'Greeter::greeting_styles' do
+    context 'given no style' do
+      it 'returns a Hash of greeting styles' do
+        expect(Greeter.greeting_styles.class).to be(Hash)
+        expect(Greeter.greeting_styles.keys).to include(:pirate, :victorian, :aussie)
+      end
+    end
+    context 'given an unknown style' do
+      it 'returns an empty string' do
+        expect(Greeter.greeting_styles(:zyx1)).to eq('')
+      end
+    end
+    context 'given a known style' do
+      it 'returns the greeting for that style' do
+        expect(Greeter.greeting_styles(:pirate)).to eq('Yar! Ahoy')
+        expect(Greeter.greeting_styles(:victorian)).to eq('Ever so delightful to meet thee')
+        expect(Greeter.greeting_styles(:aussie)).to eq("G'day")
+      end
+    end
+  end
+
   describe 'Greeter#greet_as' do
     context 'given no options' do
       it 'falls back to 1 argument greet_by_name method' do


### PR DESCRIPTION
This PR implements a `greet_as` method on the `Greeting` class, which provides the ability to do styled greetings and closes #3.

Supported styles at the moment are:
* `:pirate`
* `:victorian`
* `:aussie`
